### PR TITLE
전공피드 API 수정

### DIFF
--- a/src/main/java/T2F2/SPOT/domain/post/controller/PostController.java
+++ b/src/main/java/T2F2/SPOT/domain/post/controller/PostController.java
@@ -97,16 +97,19 @@ public class PostController {
     }
 
 
-    @GetMapping("/post/feed/major/{major}")
+    @GetMapping("/post/feed/major")
     @Operation(summary = "전공 피드", description = "전공 별, 게시글 목록을 반환하는 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Posts filtered by major returned successfully"),
             @ApiResponse(responseCode = "500", description = "Internal server error")
     })
-    public List<PostPreviewResponse> getPostFilterByMajor(
-            @PathVariable("major") String major){
-
-        return postService.findPostByMajor(major);
+    public ResponseEntity<SliceSearchPostResponse<PostPreviewResponse>> getPostFilterByMajor(
+            @RequestParam(required = true) int limit,
+            @RequestParam(defaultValue = "0") int startIndex,
+            @RequestParam(required = false) SortBy sortBy
+    ){
+        Slice<PostPreviewResponse> result = postService.getPostByMajor(limit, startIndex, sortBy);
+        return ResponseEntity.ok(new SliceSearchPostResponse<>(result));
     }
 
 

--- a/src/main/java/T2F2/SPOT/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/T2F2/SPOT/domain/post/repository/PostRepositoryCustom.java
@@ -1,6 +1,7 @@
 package T2F2.SPOT.domain.post.repository;
 
 import T2F2.SPOT.domain.post.PostFor;
+import T2F2.SPOT.domain.post.SortBy;
 import T2F2.SPOT.domain.post.dto.PostPreviewResponse;
 import T2F2.SPOT.domain.post.dto.SearchPostConditionDto;
 import T2F2.SPOT.domain.post.entity.Post;
@@ -14,7 +15,8 @@ public interface PostRepositoryCustom {
             Pageable pageable,
             SearchPostConditionDto searchPostConditionDto
     );
-    List<Post> findByMajor(String major);
+
+    Slice<PostPreviewResponse> findByMajor(Pageable pageable, String major, SortBy sortBy);
 
     List<Post> findByUserId(Long userId);
 

--- a/src/main/java/T2F2/SPOT/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/T2F2/SPOT/domain/post/repository/PostRepositoryImpl.java
@@ -1,6 +1,7 @@
 package T2F2.SPOT.domain.post.repository;
 
 import T2F2.SPOT.domain.post.PostFor;
+import T2F2.SPOT.domain.post.SortBy;
 import T2F2.SPOT.domain.post.dto.PostPreviewResponse;
 import T2F2.SPOT.domain.post.dto.SearchPostConditionDto;
 import T2F2.SPOT.domain.post.entity.Post;
@@ -60,12 +61,27 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
     }
 
     @Override
-    public List<Post> findByMajor(String major) {
-        return queryFactory
+    public Slice<PostPreviewResponse> findByMajor(Pageable pageable, String major, SortBy sortBy) {
+        List<Post> posts = queryFactory
                 .selectFrom(post)
-                .join(post.user, user)
+                .join(post.user, user).fetchJoin()
                 .where(user.major.eq(major))
+                .orderBy(getOrderSpecifier(sortBy, post))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
+
+        List<PostPreviewResponse> content = posts.stream()
+                .filter(post -> !post.getIsDeleted())
+                .map(PostPreviewResponse::of)
+                .toList();
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content = content.subList(0, pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     @Override

--- a/src/main/java/T2F2/SPOT/domain/post/service/PostService.java
+++ b/src/main/java/T2F2/SPOT/domain/post/service/PostService.java
@@ -149,17 +149,17 @@ public class PostService {
 
     /**
      * 전공에 맞는 게시글 반환
-     * @param major
      * @return 내 전공 게시글
      */
     @Transactional(readOnly = true)
-    public List<PostPreviewResponse> findPostByMajor(String major) {
-        return postRepository.findByMajor(major)
-                .stream()
-                .map(post ->
-                        post.getIsDeleted() ? null : PostPreviewResponse.of(post))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+    public Slice<PostPreviewResponse> getPostByMajor(int limit, int startIndex, SortBy sortBy) {
+        String userEmail = authService.getAuthenticatedUserEmail();
+        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
+        String major = user.getMajor();
+
+        Pageable pageable = PageRequest.of(startIndex, limit);
+
+        return postRepository.findByMajor(pageable, major, sortBy);
     }
 
 


### PR DESCRIPTION
- 변경 전
  - 전공을 파라미터로 받아서 모든 리스트를 반환

- 변경 후
  - 토큰과 무한스크롤을 위한 limit, startIndex 값을 받도록 구현
  - 토큰을 기반으로 사용자의 전공을 얻어 사용